### PR TITLE
Fixed NAVbar pathing.

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -126,17 +126,17 @@ export function NavBar() {
 
         <ul className={style.navItems}>
           <li>
-            <a href="./LandingPage/" className={style.aLinks}>
+            <a href="/" className={style.aLinks}>
               Home
             </a>
           </li>
           <li>
-            <a href="./GamesPage/" className={style.aLinks}>
+            <a href="/game" className={style.aLinks}>
               Game store
             </a>
           </li>
           <li>
-            <a href="./NewsPage/" className={style.aLinks}>
+            <a href="/new" className={style.aLinks}>
               News
             </a>
           </li>


### PR DESCRIPTION
Problem was that the url's stacked on top of each other when we clicked on the different navigation on the NAVbar. So I took and gave the paths the right name and made it so that when you click you use absolute paths instead of relative. Happy days! 
(idk why I write in English)